### PR TITLE
Markdown rules http links

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -103,6 +103,13 @@ contains a but not b and not c
 
 * write `-x` to show all notes in your db. Except those that contain a single `x`.
 
+### Markdown support
+
+I am continously adding markdown rules. Right now those are supported:
+
+* raw http link matching
+* `[text](https://example.com)`
+
 ### Discussion
 
 #reventlou on [freenode.net](https://webchat.freenode.net) and [matrix.org](https://matrix.to/#/#reventlou:matrix.org?via=matrix.org)

--- a/src/htmlRenderer.ts
+++ b/src/htmlRenderer.ts
@@ -5,20 +5,12 @@ export function translate(md: string): string {
     //let converter = new Converter();
     //return converter.makeHtml(md);
 
-    //md = linkHTTP(md); // make links clickable
     md = newline(md); // render linebreaks as html
     md = linkFILE(md);
     //md = linkHASH(md);
     md = Markdown.render(md); // apply md rules
     return md;
 }
-
-// function linkHTTP(md: string): string {
-//     const urlRegex = /(https?:\/\/[^\s]+)/g;
-//     return md.replace(urlRegex, (url) => {
-//         return '<a href="' + url + '">' + url + "</a>";
-//     });
-// }
 
 function newline(md: string): string {
     return md.replace(/\n/g, "<br>");

--- a/src/htmlRenderer.ts
+++ b/src/htmlRenderer.ts
@@ -1,32 +1,24 @@
-// // import * as highlight from "highlight.js";
-// // import { Converter } from "showdown";
-// // import { networkInterfaces } from "os";#
-// import { log } from "./logger";
-
+import * as Markdown from "./markdown";
 export function translate(md: string): string {
     // this is nice but we need to rewrite a lot for md and code syntax highlighting
     // never the less it is planed for the future. But first I need a running ims.
     //let converter = new Converter();
     //return converter.makeHtml(md);
 
-    // md = newline(md);
-    md = linkHTTP(md); // make links clickable
+    //md = linkHTTP(md); // make links clickable
     md = newline(md); // render linebreaks as html
     md = linkFILE(md);
     //md = linkHASH(md);
+    md = Markdown.render(md); // apply md rules
     return md;
 }
 
-// function newline(md: string): string {
-//     return md.replace(/\n/g, "<br>");
+// function linkHTTP(md: string): string {
+//     const urlRegex = /(https?:\/\/[^\s]+)/g;
+//     return md.replace(urlRegex, (url) => {
+//         return '<a href="' + url + '">' + url + "</a>";
+//     });
 // }
-
-function linkHTTP(md: string): string {
-    const urlRegex = /(https?:\/\/[^\s]+)/g;
-    return md.replace(urlRegex, (url) => {
-        return '<a href="' + url + '">' + url + "</a>";
-    });
-}
 
 function newline(md: string): string {
     return md.replace(/\n/g, "<br>");

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -1,0 +1,17 @@
+const httpLinks = /\[([^[]+)\]\(([^)]+)\)/gim;
+
+const rules = {
+    links: {
+        regex: httpLinks,
+        replacer: function (match, $1, $2) {
+            return `<a href="${$2}">${$1}</a>`;
+        },
+    },
+};
+
+export function render(md) {
+    Object.keys(rules).forEach((key) => {
+        md = md.replace(rules[key].regex, rules[key].replacer);
+    });
+    return md.trim();
+}

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -1,10 +1,18 @@
-const httpLinks = /\[([^[]+)\]\(([^)]+)\)/gim;
+const httpBracketLink = /\[([^[]+)\]\(([^)]+)\)/gim; // matches [text](url) note still needs https to be clickable
+const httpRawLink = /((?<!href=")https?:\/\/[^\s]+)/gim; // old raw match: /(https?:\/\/[^\s]+)/gim; // matches raw url without href=" in front
 
 const rules = {
-    links: {
-        regex: httpLinks,
+    httpBracketLink: {
+        regex: httpBracketLink,
         replacer: function (match, $1, $2) {
             return `<a href="${$2}">${$1}</a>`;
+        },
+    },
+    // matches all urls that don't have a href yet in front.
+    httpRawLink: {
+        regex: httpRawLink,
+        replacer: function (match, $1) {
+            return `<a href="${$1}">${$1}</a>`;
         },
     },
 };


### PR DESCRIPTION
* Added support for raw links (like we had before but slightly different matching),
* Added support for `[text](url)` pattern like web links.